### PR TITLE
Add app.kubernetes.io/part-of label for logs-ingester compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ helm repo add krateo https://charts.krateo.io
 helm repo update krateo
 helm install krateo-core-provider krateo/core-provider 
 ```
+
+## logs-ingester compatibility
+
+All pods deployed by this chart (core-provider, chart-inspector and the dynamically
+created CDC controllers) carry the shared label `app.kubernetes.io/part-of: krateo`, so a
+single [`logs-ingester`](https://github.com/krateoplatformops/logs-ingester) instance can
+collect their logs. Deploy the ingester in the same namespace and set
+`SELECTOR=app.kubernetes.io/part-of=krateo`.
+
+See [docs/logs-ingester-compatibility.md](docs/logs-ingester-compatibility.md) for details.

--- a/chart/assets/cdc/configmap.yaml
+++ b/chart/assets/cdc/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ "{{" }} trunc 63 .resource {{ "}}" }}
     app.kubernetes.io/version: {{ "{{" }} trunc 63 .apiVersion {{ "}}" }}
     app.kubernetes.io/component: controller
-    app.kubernetes.io/part-of: krateoplatformops
+    app.kubernetes.io/part-of: krateo
     app.kubernetes.io/managed-by: krateo
 data:
   COMPOSITION_CONTROLLER_SA_NAME: {{ "{{" }} .composition_controller_sa_name {{ "}}" }}

--- a/chart/assets/cdc/deployment.yaml
+++ b/chart/assets/cdc/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ "{{" }} trunc 63 .resource {{ "}}" }}
     app.kubernetes.io/version: {{ "{{" }} trunc 63 .apiVersion {{ "}}" }}
     app.kubernetes.io/component: controller
-    app.kubernetes.io/part-of: krateoplatformops
+    app.kubernetes.io/part-of: krateo
     app.kubernetes.io/managed-by: krateo
 spec:
   {{- if not .Values.cdc.autoscaling.enabled }}
@@ -23,6 +23,7 @@ spec:
       namespace: {{ "{{" }} .namespace {{ "}}" }}
       labels:
         app.kubernetes.io/name: {{ "{{" }} trunc 63 .name {{ "}}" }}
+        app.kubernetes.io/part-of: krateo
     spec:
       serviceAccountName: {{ "{{" }} .serviceAccountName {{ "}}" }}
       securityContext:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "core-provider.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: krateo
 {{- end }}
 
 {{/*
@@ -72,6 +73,7 @@ helm.sh/chart: {{ include "core-provider.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: krateo
 {{- end }}
 
 {{/*

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,7 +106,7 @@ chartInspector:
   image:
     repository: ghcr.io/krateoplatformops/chart-inspector
     pullPolicy: IfNotPresent
-    tag: 1.0.0
+    tag: 1.0.2
   
   replicaCount: 1
   imagePullSecrets: []
@@ -139,7 +139,7 @@ cdc:
   image:
     repository: ghcr.io/krateoplatformops/composition-dynamic-controller
     pullPolicy: IfNotPresent
-    tag: 1.0.0
+    tag: 1.0.2
   replicaCount: 1
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
This pull request updates the labeling convention for all pods and resources deployed by the chart to use the shared label app.kubernetes.io/part-of: krateo instead of the previous value. It also documents compatibility with the logs-ingester tool, making it easier to collect logs from all related components. The most important changes are:

**Labeling Standardization:**

* Updated the value of the label `app.kubernetes.io/part-of` from `krateoplatformops` to `krateo` in `chart/assets/cdc/configmap.yaml` and `chart/assets/cdc/deployment.yaml` to ensure consistency across all deployed resources. [[1]](diffhunk://#diff-b9d52736ef124de94ea987da3548d8107ce97c275d47045c25770fde515f15f6L11-R11) [[2]](diffhunk://#diff-2252d6a99b3027e3ef5fac7f41b25013416a3b6998aa55ec2ccd7d91286f855dL11-R11)
* Added the label `app.kubernetes.io/part-of: krateo` to additional resource sections in `chart/assets/cdc/deployment.yaml` and in the Helm template helpers (`chart/templates/_helpers.tpl`) for consistent labeling. [[1]](diffhunk://#diff-2252d6a99b3027e3ef5fac7f41b25013416a3b6998aa55ec2ccd7d91286f855dR26) [[2]](diffhunk://#diff-a695820e1f93e7decd902e54573160d357bc57f3faeec7e501cc7d2c607baaaaR43) [[3]](diffhunk://#diff-a695820e1f93e7decd902e54573160d357bc57f3faeec7e501cc7d2c607baaaaR76)

**Documentation Improvements:**

* Added a new section to `README.md` explaining logs-ingester compatibility, including instructions for deploying the ingester and referencing detailed documentation.